### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     ],
     "categories": [
         "Languages",
+        "Formatters",
         "Other"
     ],
     "keywords": [


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.
